### PR TITLE
Updated path to new NHD S3 bucket

### DIFF
--- a/1_crosswalk_fetch/src/fetch_nhdhr.R
+++ b/1_crosswalk_fetch/src/fetch_nhdhr.R
@@ -69,7 +69,7 @@ GNIS_Name_xwalk <- function(ind_file, ...){
 
   sf_lakes <- rbind(...)
   deduped_sf_lakes <- st_drop_geometry(sf_lakes[!duplicated(sf_lakes$site_id), ]) %>%
-    dplyr::select(site_id, GNIS_Name)
+    dplyr::select(site_id, gnis_name)
 
   saveRDS(deduped_sf_lakes, data_file)
   gd_put(ind_file, data_file)
@@ -80,7 +80,7 @@ combine_nhd_sfs <- function(ind_file, ...){
 
   sf_lakes <- rbind(...)
   deduped_sf_lakes <- sf_lakes[!duplicated(sf_lakes$site_id), ] %>%
-    dplyr::select(site_id,  Elevation, FType, FCode)
+    dplyr::select(site_id,  elevation, ftype, fcode)
 
   saveRDS(deduped_sf_lakes, data_file)
   gd_put(ind_file, data_file)

--- a/1_crosswalk_fetch/src/fetch_nhdhr.R
+++ b/1_crosswalk_fetch/src/fetch_nhdhr.R
@@ -2,7 +2,7 @@
 
 
 create_nhd_HR_download_plan <- function(states, min_size, d_tolerance, remove_IDs = NULL, keep_IDs = NULL){
-  base_url <- 'ftp://rockyftp.cr.usgs.gov/vdelivery/Datasets/Staged/Hydrography/NHD/State/HighResolution/GDB/NHD_H_%s_State_GDB.zip'
+  base_url <- 'https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHD/State/GDB/NHD_H_%s_State_GDB.zip'
 
   fetch_as_sf_step <- create_task_step(
     step_name = 'fetch_NHD_as_sf',
@@ -41,15 +41,20 @@ fetch_NHD_as_sf <- function(url,min_size, d_tol){
     unlink(unzip_dir, recursive = TRUE)
     unlink(dl_dest)
   })
-
+	
+  if(getOption('timeout') < 120){
+  	options(timeout = 120)
+  }
   download.file(url, destfile = dl_dest, quiet = TRUE, method='curl')
+  #GET(url, write_disk( dl_dest, overwrite=TRUE))
   unzip(dl_dest, exdir = unzip_dir)
 
   sf::read_sf(file.path(unzip_dir,paste0(tools::file_path_sans_ext(basename(url)), '.gdb')), layer = 'NHDWaterbody') %>%
-    filter(FType %in% c(390, 436, 361)) %>% #select only lakes/ponds/reservoirs. This drops things like swamp/marsh
-    mutate(area_m2 = AreaSqKm * 1000000) %>%
+  	filter(ftype %in% c(390, 436, 361)) %>% #select only lakes/ponds/reservoirs. This drops things like swamp/marsh
+    mutate(area_m2 = areasqkm * 1000000) %>%
     filter(area_m2 > min_size) %>%
-    mutate(site_id = paste0('nhdhr_', Permanent_Identifier)) %>% dplyr::select(site_id, GNIS_Name, Elevation, FType, FCode) %>%  #geometry selected automatically
+    mutate(site_id = paste0('nhdhr_', permanent_identifier)) %>%
+  	dplyr::select(site_id, gnis_name, elevation, ftype, fcode) %>%  #geometry selected automatically
     # bad Idaho site!
     filter(site_id != 'nhdhr_{5BEDE13F-C94B-4501-B979-E00C29EA374B}') %>%
     sf::st_transform(crs = 4326) %>%

--- a/1_crosswalk_fetch/src/fetch_nhdhr.R
+++ b/1_crosswalk_fetch/src/fetch_nhdhr.R
@@ -46,7 +46,6 @@ fetch_NHD_as_sf <- function(url,min_size, d_tol){
   	options(timeout = 120)
   }
   download.file(url, destfile = dl_dest, quiet = TRUE, method='curl')
-  #GET(url, write_disk( dl_dest, overwrite=TRUE))
   unzip(dl_dest, exdir = unzip_dir)
 
   sf::read_sf(file.path(unzip_dir,paste0(tools::file_path_sans_ext(basename(url)), '.gdb')), layer = 'NHDWaterbody') %>%

--- a/lib/cfg/gd_config.yml
+++ b/lib/cfg/gd_config.yml
@@ -1,1 +1,1 @@
-folder: 1hDyYN17kLZVaOJ5G3eEVPKiHxx4Apy4b
+folder: 1Yc4lAdCMBWD1Utdj7G9VL4-Z_WJWneg0

--- a/lib/cfg/gd_config.yml
+++ b/lib/cfg/gd_config.yml
@@ -1,1 +1,1 @@
-folder: 1Yc4lAdCMBWD1Utdj7G9VL4-Z_WJWneg0
+folder: 1hDyYN17kLZVaOJ5G3eEVPKiHxx4Apy4b


### PR DESCRIPTION
Updated the NHD retrieval path from the old `rockyftp` server to current S3 bucket.  Updates include:
- Correct path to NHD lakes
- Increase `timout` a little to reduce retries due to download timeout for bigger states
- Updated variable names to match those in the current NHD version (only difference is they're lowercase in the new one)

Lakes aren't one to one between the canonical lakes from the manuscript and the most recent NHD version.  Lakes from the new path include 98% of the canonical lakes and an additional ~3k that are new/not in the canonical lakes.